### PR TITLE
Support footnote definitions in output

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -90,6 +90,20 @@ function addFootnoteDefinition(node) {
     this.footnotes.push(node);
 }
 
+function footnoteItem(node) {
+    var item = node;
+    var attributes = {};
+    var result;
+
+    result = this.all(item);
+
+    if (node.attributes != null) {
+        attributes.id = node.attributes.id;
+    }
+
+    return h(this, node, 'li', attributes, result);
+}
+
 /**
  * Stringify all footnote definitions, if any.
  *
@@ -115,7 +129,7 @@ function generateFootnotes() {
     while (++index < length) {
         def = definitions[index];
 
-        results[index] = self.listItem({
+        results[index] = footnoteItem.call(this, {
             'type': 'listItem',
             'attributes': {
                 'id': 'fn-' + def.identifier
@@ -132,7 +146,7 @@ function generateFootnotes() {
                 }]
             }),
             'position': def.position
-        }, {});
+        });
     }
 
     content = [h(self, null, 'hr', {}),

--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -128,7 +128,7 @@ function generateFootnotes() {
                 },
                 'children': [{
                     'type': 'text',
-                    'value': '↩'
+                    'value': String.fromCharCode(0x21a9)
                 }]
             }),
             'position': def.position
@@ -136,7 +136,7 @@ function generateFootnotes() {
     }
 
     content = [h(self, null, 'hr', {}),
-        h(self, null, 'ol', results, true)];
+        h(self, null, 'ol', {}, results)];
 
     return h(self, null, 'div', {
         'className': 'footnotes'
@@ -250,7 +250,7 @@ function root(node) {
     visit(node, 'definition', addDefinition, self);
     visit(node, 'footnoteDefinition', addFootnoteDefinition, self);
 
-    var children = self.all(node);
+    var children = self.all(node).concat(self.generateFootnotes());
 
     return React.createElement.apply(React, ['div', null].concat(children));
     // return (result ? result + '\n' : '') + self.generateFootnotes();

--- a/lib/h.js
+++ b/lib/h.js
@@ -5,6 +5,8 @@ var React = require('react');
 var CLOSING = ['hr', 'img', 'br'];
 var key = 0;
 
+var BLACKLISTED_ATTRIBUTES = ['id', 'name'];
+
 /**
  * Compile a `node`, in `context`, into HTML.
  *
@@ -44,7 +46,9 @@ function h(context, node, name, attributes, children) {
 
     if (node != null && node.attributes){
         attributes = Object.keys(node.attributes).reduce(function(memo, key) {
-            memo[key] = node.attributes[key];
+            if (BLACKLISTED_ATTRIBUTES.indexOf(key) === -1) {
+                memo[key] = node.attributes[key];
+            }
 
             return memo;
         }, attributes);

--- a/lib/h.js
+++ b/lib/h.js
@@ -42,6 +42,14 @@ function h(context, node, name, attributes, children) {
 
     attributes.key = ++key;
 
+    if (node != null && node.attributes){
+        attributes = Object.keys(node.attributes).reduce(function(memo, key) {
+            memo[key] = node.attributes[key];
+
+            return memo;
+        }, attributes);
+    }
+
     if (closing) {
         return React.createElement(name, attributes);
     } else {

--- a/test/fixtures/footnotes/output.html
+++ b/test/fixtures/footnotes/output.html
@@ -48,4 +48,4 @@ tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</span></p></div>
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</span></p><div class="footnotes"><hr><ol><li id="fn-1"><p><span>This reference style footnote can contains paragraphs.</span></p><ul><li><span>and lists</span></li></ul><a href="#fnref-1" class="footnote-backref"><span>↩</span></a></li><li id="fn-2"><p><span>Normal footnote.</span></p><a href="#fnref-2" class="footnote-backref"><span>↩</span></a></li><li id="fn-3"><span>charlie india</span><a href="#fnref-3" class="footnote-backref"><span>↩</span></a></li></ol></div></div>


### PR DESCRIPTION
This patch adds the footnote defintions to the output of this plugin. As part of this, I added the node's `attributes` to the props for each react component, so you can specify className, id etc.
