### PR TITLE
Remove React dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "mdast"
   ],
   "dependencies": {
-    "react": "^0.13.3",
     "repeat-string": "^1.5.2"
   },
   "repository": {
@@ -31,6 +30,7 @@
     "mdast": ">=0.25.0"
   },
   "devDependencies": {
+    "react": "^0.13.3",
     "browserify": "^10.0.0",
     "commonmark.json": "^0.20.0",
     "eslint": "^0.24.0",


### PR DESCRIPTION
mdast-react will use whatever React version is already used in an app. Works with React 0.14.0-rc1.

I've deliberately not put React into `peerDependencies` because I ran into too many problems with other libraries that did.
