### PR TITLE
Allow custom react components to be passed in

### DIFF
--- a/lib/h.js
+++ b/lib/h.js
@@ -53,13 +53,18 @@ function h(context, node, name, attributes, children) {
         }, attributes);
     }
 
+    // Get any component overrides passed into context.options
+    // Allows rendering custom elements instead of <p>, <li>, etc.
+    var components = context.options.mdastReactComponents;
+    var component = components[name] ? components[name] : name;
+
     if (closing) {
-        return React.createElement(name, attributes);
+        return React.createElement(component, attributes);
     } else {
         if (!Array.isArray(children)) {
             children = [children];
         }
-        var args = [name, attributes].concat(children);
+        var args = [component, attributes].concat(children);
         return React.createElement.apply(React, args);
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,18 @@ All options, including the `options` object itself, are optional:
 *   `sanitize` (`boolean`, default: `false`)
     — Whether or not to allow the use of HTML inside markdown.
 
+*   `mdastReactComponents` (`object`, default: `undefined`)
+    — Provides a way to override default elements (`<a>`, `<p>`, etc)
+    by defining an object comprised of `element: Component` key-value
+    pairs. For example, to output `<MyLink>` components instead of
+    `<a>`, and `<MyParagraph>` instead of `<p>`:
+    ```js
+    mdastReactComponents: {
+      a: MyLink,
+      p: MyParagraph
+    }
+    ```
+
 These can passed to `mdast.use()` as a second argument.
 
 You can define these in `.mdastrc` or `package.json` [files](https://github.com/wooorm/mdast/blob/master/doc/mdastrc.5.md)


### PR DESCRIPTION
Allows passing in custom react components to replace the standard `<p>`, `<li>`, `<a>`, etc.
