### PR TITLE
Add option to prevent `<p>` tags in `<blockquote>`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function plugin(mdast, options) {
     proto.options.xhtml = false;
     proto.options.sanitize = false;
     proto.options.entities = 'true';
+    proto.options.paragraphBlockquotes = true;
 
     /**
      * Extensible constructor.

--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -292,6 +292,20 @@ function root(node) {
  * @this {HTMLCompiler}
  */
 function blockquote(node) {
+    // If we specify paragraphBlockquotes = false, remove paragraph elements
+    // from the node and replace them with their children
+    if (!this.options.paragraphBlockquotes) {
+        var newChildren = [];
+        node.children.forEach(function (child) {
+            if (child.type === 'paragraph') {
+                newChildren = newChildren.concat(child.children);
+            } else {
+                newChildren.push(child);
+            }
+        });
+        node.children = newChildren;
+    }
+
     return h(this, node, 'blockquote', {}, this.all(node), true);
 }
 

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,9 @@ All options, including the `options` object itself, are optional:
 *   `sanitize` (`boolean`, default: `false`)
     — Whether or not to allow the use of HTML inside markdown.
 
+*   `paragraphBlockquotes` (`boolean`, default: `true`)
+    — Wraps content of `<blockquote>` in a `<p>` element.
+
 *   `mdastReactComponents` (`object`, default: `undefined`)
     — Provides a way to override default elements (`<a>`, `<p>`, etc)
     by defining an object comprised of `element: Component` key-value
@@ -103,7 +106,7 @@ All options, including the `options` object itself, are optional:
 
 These can passed to `mdast.use()` as a second argument.
 
-You can define these in `.mdastrc` or `package.json` [files](https://github.com/wooorm/mdast/blob/master/doc/mdastrc.5.md)
+Options other than `mdastReactComponents` can be defined in `.mdastrc` or `package.json` [files](https://github.com/wooorm/mdast/blob/master/doc/mdastrc.5.md)
 too. An example `.mdastrc` file could look as follows:
 
 ```json


### PR DESCRIPTION
Exposes `paragraphBlockquotes` (default: true) as an option for the
purpose of suppressing wrapping of `<blockquote>` content in a `<p>` tag.

When `true` (current behaviour):

``` html
<blockquote><p>Content...</p></blockquote>
```

When `false`:

``` html
<blockquote>Content...</blockquote>
```
