### PR TITLE
Allow to skip sanitation

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ function plugin(processor, options) {
     var settings = options || {};
     var createElement = settings.createElement || globalCreateElement;
     var components = settings.remarkReactComponents || {};
+    var clean = settings.sanitize !== false;
+    var scheme = clean && (typeof settings.sanitize !== 'boolean') ? settings.sanitize : null;
 
     /**
      * Wrapper around `createElement` to pass
@@ -73,14 +75,18 @@ function plugin(processor, options) {
      * @return {ReactElement} - React element.
      */
     function compile(node) {
-        var clean = sanitize({
+        var hast = {
             type: 'element',
             tagName: 'div',
             properties: {},
             children: toHAST(node).children
-        }, settings.sanitize);
+        };
 
-        return toH(h, clean, settings.prefix);
+        if (clean) {
+            hast = sanitize(hast, scheme);
+        }
+
+        return toH(h, hast, settings.prefix);
     }
 
     Compiler.prototype.compile = compile;

--- a/readme.md
+++ b/readme.md
@@ -75,11 +75,11 @@ React.render(<App />, document.getElementById('app'));
 
 All options, including the `options` object itself, are optional:
 
-*   `sanitize` (`object`, default: `undefined`)
+*   `sanitize` (`object` or `boolean`, default: `undefined`)
     — Sanitation schema to use. Passed to
     [hast-util-sanitize](https://github.com/wooorm/hast-util-sanitize).
-    The default schema, if none is passed, adheres to GitHub’s sanitation
-    rules.
+    The default schema, if none or `true` is passed, adheres to GitHub’s
+    sanitation rules. If `false` is passed, it does not sanitize input.
 
 *   `prefix` (`string`, default: `h-`)
     — React key.

--- a/test/index.js
+++ b/test/index.js
@@ -173,9 +173,20 @@ function isHidden(filePath) {
                             return React.createElement('h2', props)
                         }
                     }
-                }).process(markdown, {}).contents
+                }).process(markdown, {}).contents;
 
                 assert.equal(React.renderToStaticMarkup(vdom), '<div><h2>Foo</h2></div>');
+            });
+
+            it("does not sanitize input when 'sanitize' option is set to false", function() {
+                var markdown = '```empty\n```';
+                var vdom = remark().use(reactRenderer, {
+                    createElement: React.createElement,
+                    sanitize: false
+                }).process(markdown, {}).contents;
+
+                // If sanitation were done, 'class' property should be removed.
+                assert.equal(React.renderToStaticMarkup(vdom), '<div><pre><code class="language-empty"></code></pre></div>');
             });
         });
 


### PR DESCRIPTION
I found that `settings.sanitize` is not properly reflected.  When I set it to `false`, DOM was sanitized.  I found that the passed parameter to `sanitize()` is wrong.  The second parameter should be `schema`.

https://github.com/wooorm/hast-util-sanitize/blob/master/lib/index.js#L42

I fixed this looking the [remark-html](https://github.com/wooorm/remark-html) source code.  Now it works on my machine.  
