### PR TITLE
Add 'toHast' options to control HAST transformation

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function plugin(processor, options) {
     var components = settings.remarkReactComponents || {};
     var clean = settings.sanitize !== false;
     var scheme = clean && (typeof settings.sanitize !== 'boolean') ? settings.sanitize : null;
+    var toHastOptions = settings.toHast || {};
 
     /**
      * Wrapper around `createElement` to pass
@@ -79,7 +80,7 @@ function plugin(processor, options) {
             type: 'element',
             tagName: 'div',
             properties: {},
-            children: toHAST(node).children
+            children: toHAST(node, toHastOptions).children
         };
 
         if (clean) {

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,11 @@ All options, including the `options` object itself, are optional:
     }
     ```
 
+*   `toHast` (`object`, default: `{}`)
+    — Provides options for transforming MDAST document to HAST.
+    Valid values for the object are `options` parameter of
+    [this API](https://github.com/rhysd/mdast-util-to-hast#api).
+
 These can passed to `remark.use()` as a second argument.
 
 ## Integrations

--- a/readme.md
+++ b/readme.md
@@ -102,8 +102,8 @@ All options, including the `options` object itself, are optional:
 
 *   `toHast` (`object`, default: `{}`)
     — Provides options for transforming MDAST document to HAST.
-    Valid values for the object are `options` parameter of
-    [this API](https://github.com/rhysd/mdast-util-to-hast#api).
+    See [mdast-util-to-hast](https://github.com/wooorm/mdast-util-to-hast#api)
+    for settings.
 
 These can passed to `remark.use()` as a second argument.
 

--- a/test/index.js
+++ b/test/index.js
@@ -188,6 +188,17 @@ function isHidden(filePath) {
                 // If sanitation were done, 'class' property should be removed.
                 assert.equal(React.renderToStaticMarkup(vdom), '<div><pre><code class="language-empty"></code></pre></div>');
             });
+
+            it('passes toHast options to inner toHAST() function', function() {
+                var markdown = '# Foo';
+
+                var vdom = remark().use(reactRenderer, {
+                    createElement: React.createElement,
+                    toHast: {allowDangerousHTML: true}
+                }).process(markdown, {}).contents;
+
+                assert.equal(React.renderToStaticMarkup(vdom), '<div><h1>Foo</h1></div>');
+            });
         });
 
         /**


### PR DESCRIPTION
Hello again,

I implemented 'toHast' option, which will be passed to internal `toHAST()` function call.  I added this because I want to control the transformation.
Default value of the option is empty and it doesn't break current behavior :+1:
