### PR TITLE
Remove table whitespace warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function plugin(processor, options) {
          * pretty lines for now:
          * https://github.com/facebook/react/pull/7081
          */
-        if (children && TABLE_ELEMENTS.indexOf(component) !== -1) {
+        if (children && TABLE_ELEMENTS.indexOf(component.name || component) !== -1) {
             children = children.filter(function (child) {
                 return child !== '\n';
             });


### PR DESCRIPTION
Hi 👋 

Certain table elements are generating warnings in React due to whitespace inside the component:

`Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of <table>.`

I saw that the library already tries to remove this whitespace, but this only works for [DOM components and not composite ones](https://facebook.github.io/react/docs/test-utils.html#isdomcomponent). When printing the component variable, we get this output:

* `thead` (DOM component)
* `[Function: table]` (Composite component)

Since the composite components are functions, they do not get identified as table elements and therefore retain their whitespace. This PR will try and match against `component.name` if available, and will fallback to the current implementation otherwise.