### PR TITLE
Avoid warning of unknown prop `align`

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,11 +100,12 @@ function remarkReact(options) {
     return TableCell;
 
     function TableCell(props) {
-      return createElement(tagName, xtend(props, {
-        align: undefined,
+      const fixedProps = xtend(props, {
         children: undefined,
         style: {textAlign: props.align}
-      }), props.children);
+      });
+      delete fixedProps.align;
+      return createElement(tagName, fixedProps, props.children);
     }
   }
 }


### PR DESCRIPTION
It seems that setting `undefined` with `xtend` does not work.
It produces following warning from react:

```
Warning: Unknown prop `align` on <th> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
```

The warning disappears when removing it with `delete` statement.