### PR TITLE
Camelize prop keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var toHAST = require('mdast-util-to-hast');
 var sanitize = require('hast-util-sanitize');
 var toH = require('hast-to-hyperscript');
 var xtend = require('xtend');
+var camelize = require('camelize');
 
 var globalCreateElement;
 
@@ -67,7 +68,7 @@ function remarkReact(options) {
       });
     }
 
-    return createElement(component, props, children);
+    return createElement(component, camelize(props), children);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "Jeremy Stucki <jeremy@interactivethings.com>"
   ],
   "dependencies": {
+    "camelize": "^1.0.0",
     "hast-to-hyperscript": "^2.0.1",
     "hast-util-sanitize": "^1.0.0",
     "mdast-util-to-hast": "^2.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -134,6 +134,33 @@ function isHidden(filePath) {
         assert.equal(React.renderToStaticMarkup(vdom), '<div><h2>Foo</h2></div>');
       });
 
+      it('should camelize prop keys', function () {
+        var markdown = '# Foo';
+
+        const transformer = function () {
+          return transform;
+
+          function transform(tree) {
+            tree.children[0].data = {hProperties: {customAttr: 'Bar'}};
+          }
+        };
+
+        var h1Props;
+        var vdom = remark().use(transformer).use(reactRenderer, {
+          createElement: React.createElement,
+          remarkReactComponents: {
+            h1: function (props) {
+              h1Props = props;
+              return React.createElement('h1', props);
+            }
+          },
+          sanitize: false
+        }).processSync(markdown).contents;
+
+        React.renderToStaticMarkup(vdom);
+        assert.equal(h1Props.customAttr, 'Bar');
+      });
+
       it('does not sanitize input when `sanitize` option is set to false', function () {
         var markdown = '```empty\n```';
         var vdom = remark().use(reactRenderer, {


### PR DESCRIPTION
[hast-to-hyperscript](
https://github.com/syntax-tree/hast-to-hyperscript/blob/5afc791ca5677dc4ba551de0c1e8fdb81efff265/index.js#L138) make prop keys to kebab-case.

But almost react component needs props that has camel case keys.