### PR TITLE
Use hast-util-table-cell-style to adjust align properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = remarkReact;
 var toHAST = require('mdast-util-to-hast');
 var sanitize = require('hast-util-sanitize');
 var toH = require('hast-to-hyperscript');
-var xtend = require('xtend');
+var tableCellStyle = require('@mapbox/hast-util-table-cell-style');
 
 var globalCreateElement;
 
@@ -37,10 +37,7 @@ function remarkReact(options) {
   var clean = settings.sanitize !== false;
   var scheme = clean && (typeof settings.sanitize !== 'boolean') ? settings.sanitize : null;
   var toHastOptions = settings.toHast || {};
-  var components = xtend({
-    td: createTableCellComponent('td'),
-    th: createTableCellComponent('th')
-  }, settings.remarkReactComponents);
+  var components = settings.remarkReactComponents || {};
 
   this.Compiler = compile;
 
@@ -88,24 +85,8 @@ function remarkReact(options) {
       hast = sanitize(hast, scheme);
     }
 
+    hast = tableCellStyle(hast);
+
     return toH(h, hast, settings.prefix);
-  }
-
-  /**
-   * Create a functional React component for a cell.
-   * We need this because GFM uses `align`, whereas React
-   * forbids that and wants `style.textAlign` instead.
-   */
-  function createTableCellComponent(tagName) {
-    return TableCell;
-
-    function TableCell(props) {
-      var fixedProps = xtend(props, {
-        children: undefined,
-        style: {textAlign: props.align}
-      });
-      delete fixedProps.align;
-      return createElement(tagName, fixedProps, props.children);
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,10 @@
     "Jeremy Stucki <jeremy@interactivethings.com>"
   ],
   "dependencies": {
+    "@mapbox/hast-util-table-cell-style": "^0.1.1",
     "hast-to-hyperscript": "^3.0.0",
     "hast-util-sanitize": "^1.0.0",
-    "mdast-util-to-hast": "^2.0.0",
-    "standard-changelog": "^0.0.1",
-    "xtend": "^4.0.1"
+    "mdast-util-to-hast": "^2.0.0"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.0.0",
@@ -32,6 +31,7 @@
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-recommended": "^2.0.0",
     "remark-toc": "^4.0.0",
+    "standard-changelog": "^0.0.1",
     "vfile": "^2.0.0",
     "xo": "^0.17.1"
   },

--- a/readme.md
+++ b/readme.md
@@ -100,12 +100,6 @@ All options, including the `options` object itself, are optional:
     }
     ```
 
-    Note: as GFM uses `align` on `td` and `th`, and React doesn’t like that,
-    we [overwrite](https://github.com/mapbox/remark-react/blob/master/index.js#L94)
-    them through `remarkReactComponents` to use `style.textAlign` instead.
-    This means that if you set `td` or `td`, you’ll need to handle `align`
-    yourself.
-
 *   `toHast` (`object`, default: `{}`)
     — Provides options for transforming MDAST document to HAST.
     See [mdast-util-to-hast](https://github.com/wooorm/mdast-util-to-hast#api)


### PR DESCRIPTION
Allows removal of the readme warning that users might need to perform this step themselves if they use custom components. The transformation of align to a style will happen before their custom component is invoked.

@wooorm: I needed to do this same thing in another package I'm working on, so I tried creating a more reusable way to accomplish the same thing with https://github.com/mapbox/hast-util-table-cell-style. Before I merge this, I'd love a quick look to see if you think this is the right approach.