### PR TITLE
Include standard changelog as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "hast-to-hyperscript": "^3.0.0",
     "hast-util-sanitize": "^1.0.0",
     "mdast-util-to-hast": "^2.0.0",
-    "standard-changelog": "^0.0.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
@@ -32,6 +31,7 @@
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-recommended": "^2.0.0",
     "remark-toc": "^4.0.0",
+    "standard-changelog": "^0.0.1",
     "vfile": "^2.0.0",
     "xo": "^0.17.1"
   },


### PR DESCRIPTION
Resolves a security alert message when including remark-react as a dependency

```
✗ Low severity vulnerability found on lodash@3.10.1
- desc: Prototype Pollution
- info: https://snyk.io/vuln/npm:lodash:20180130
- from: remark-react@4.0.1 > standard-changelog@0.0.1 > conventional-changelog-core@0.0.2 > conventional-commits-parser@0.1.2 > lodash@3.10.1
No direct dependency upgrade can address this issue.
```